### PR TITLE
Bugfixes: Change url of episode wizard, change promotional content selection and change the way description is filled

### DIFF
--- a/src/anchorfm-pupeteer/index.js
+++ b/src/anchorfm-pupeteer/index.js
@@ -249,10 +249,11 @@ async function postEpisode(youtubeVideoInfo) {
     }
 
     logger.info('-- Selection promotional content(formerly content sponsorship - sponsored or not sponsored)');
-    const selectorForSponsoredContent = env.IS_SPONSORED
-      ? 'input[type="radio"][name="sponsored-content"]'
-      : 'input[type="radio"][id="no-sponsored-content"]';
-    await clickSelector(page, selectorForSponsoredContent, { visible: true });
+    if (env.IS_SPONSORED) {
+      const promotionalContentCheckboxLabelSelector =
+        '::-p-xpath(//input[@name="podcastEpisodeContainsSponsoredContent"]/parent::*)';
+      await clickSelector(page, promotionalContentCheckboxLabelSelector);
+    }
   }
 
   async function fillReviewAndPublishDetails() {

--- a/src/anchorfm-pupeteer/index.js
+++ b/src/anchorfm-pupeteer/index.js
@@ -54,7 +54,7 @@ async function postEpisode(youtubeVideoInfo) {
     logger.info('Launching puppeteer');
     browser = await puppeteer.launch({ args: ['--no-sandbox'], headless: env.PUPETEER_HEADLESS });
 
-    page = await openNewPage('https://podcasters.spotify.com/pod/dashboard/episode/wizard');
+    page = await openNewPage('https://creators.spotify.com/pod/dashboard/episode/wizard');
 
     logger.info('Setting language to English');
     await setLanguageToEnglish();


### PR DESCRIPTION
Commits:

- Change url that opens new episode wizard.
- Change selector of promotional content selector.
- Change the way description is filled: instead of using page.type, we paste the description.
  This solves a new issue that arose: characters are getting out of order with page.type, so the way of filling description   is changed from page.type to pasting the description.

  Note that it is important to first focus the description textbox, then invoke selectAll for the textbox before pasting the description.