### PR TITLE
Allow setting user agent with environment variables and set the defalt user agent to a value that does not have HeadlessChrome/XXX.X.X.X

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,26 @@ env:
   SET_PUBLISH_DATE: true
 ```
 
+### Set user agent
+
+We allow setting the user agent with the environment variable `USER_AGENT`.
+
+You can use a browser of your choice to open `https://httpbin.io/user-agent` and view its user agent, then copy that value to set the
+environment variable `USER_AGENT`.
+
+Motivation: the reason we set user agent is to avoid sites to detect that automation is used, for example,
+Spotify might sometimes show different page for login with the default user agent for headless puppeteer.
+
+The default user agent used when puppeteer is launched in a headless mode is:
+
+`Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/131.0.0.0 Safari/537.36`
+
+Even though we allow setting a custom user agent, by default, we set the user agent to look something like:
+
+`Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36`.
+
+
+
 ## Multiple shows per repository
 
 It is possible to use a single repository to maintain several shows.

--- a/src/environment-variables/index.js
+++ b/src/environment-variables/index.js
@@ -20,6 +20,8 @@ const defaultValues = {
   THUMBNAIL_FILE_FORMAT: 'jpg',
   THUMBNAIL_FILE_TEMPLATE: 'thumbnail.%(ext)s',
   PUPPETEER_HEADLESS: true,
+  // NOTE: The user agent should probably be updated regularly, for example when updating puppeteer version
+  USER_AGENT: 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36',
 };
 
 const dotEnvVariables = parseDotEnvVariables();
@@ -91,4 +93,5 @@ module.exports = {
     getDotEnvironmentVariable('THUMBNAIL_FILE_FORMAT')
   ),
   PUPPETEER_HEADLESS: getBoolean(getDotEnvironmentVariable('PUPPETEER_HEADLESS')),
+  USER_AGENT: getDotEnvironmentVariable('USER_AGENT'),
 };

--- a/src/spotify-puppeteer/index.js
+++ b/src/spotify-puppeteer/index.js
@@ -111,6 +111,12 @@ async function postEpisode(youtubeVideoInfo) {
 
   async function openNewPage(url) {
     const newPage = await browser.newPage();
+    /* The reason we set user agent is to avoid sites to detect that automation is used.
+     * For example, Spotify might sometimes show different page for login with the default user agent for headless puppeteer.
+     * The default user agent for headless puppeteer looks something like:
+     * Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/131.0.0.0 Safari/537.36
+     */
+    await newPage.setUserAgent(env.USER_AGENT);
     await newPage.goto(url);
     await newPage.setViewport({ width: 2560, height: 1440 });
     return newPage;


### PR DESCRIPTION
The reason we set user agent is to avoid sites to detect that automation is used.

For example, Spotify might sometimes show different page for login with the default user agent for headless puppeteer.

Sometimes, spotify might show the login page without the password field:

![Screenshot_20250331_235611](https://github.com/user-attachments/assets/982666fd-4f7b-48b6-89af-b27549c6dff4)

And the process would fail when `Continue` is pressed:

![Screenshot_20250331_235804](https://github.com/user-attachments/assets/5998ca59-aa45-4c16-a777-5d52bd1ed24a)

Even though this is Spotify's issue, I've noticed that this page is not displayed(or maybe it is not displayed too frequently) when the user agent does not contain `HeadlessChrome`.